### PR TITLE
feat: #23 add custom sorting pattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ exifTool {
 }
 ```
 
+## Settings
+
+All available settings with their defaults are defined in [`core/src/main/resources/reference.conf`](core/src/main/resources/reference.conf).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `exifTool.path` | `""` (use PATH) | Path to the exiftool executable |
+| `dateTime.timeZone` | System default | Default timezone for date/time parsing ([TZDB identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)) |
+| `rename.pattern` | `IMG_${date,yyyyMMdd}_${date,HHmmss}` | Pattern for renaming files |
+| `sort.pattern` | `${date,yyyy}/${date,MM}` | Pattern for folder structure when sorting |
+
+### Date Pattern Syntax
+
+Both `rename.pattern` and `sort.pattern` use the `${date,FORMAT}` syntax where FORMAT follows [Java DateTimeFormatter](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html) patterns.
+
+**Sort pattern examples:**
+
+| Pattern | Output | Description |
+|---------|--------|-------------|
+| `${date,yyyy}/${date,MM}` | `2024/07` | Year/month (default) |
+| `${date,yyyy}/${date,MM}/${date,dd}` | `2024/07/15` | Year/month/day |
+| `${date,yyyy}/${date,ww}` | `2024/29` | Year/week of year |
+| `${date,yyyy-MM}` | `2024-07` | Flat year-month |
+| `${date,yyyy}/Q${date,Q}` | `2024/Q3` | Year/quarter |
+
+The sort pattern can be overridden via command line using `-p` or `--pattern`:
+
+```bash
+exifutils sort -o /output -p '${date,yyyy}/${date,MM}/${date,dd}' /input
+```
+
 ## Logging
 
 Log files are stored in platform-specific locations:

--- a/config/application-template.conf
+++ b/config/application-template.conf
@@ -13,3 +13,14 @@ dateTime {
   # If not set, system default time zone is used.
   #timeZone = ""
 }
+
+sort {
+  # Pattern for folder structure when sorting files by date.
+  # Uses ${date,FORMAT} syntax with Java DateTimeFormatter patterns.
+  # Examples:
+  #   ${date,yyyy}/${date,MM}             -> 2024/07 (year/month, default)
+  #   ${date,yyyy}/${date,MM}/${date,dd}  -> 2024/07/15 (year/month/day)
+  #   ${date,yyyy}/${date,ww}             -> 2024/28 (year/week of year)
+  #   ${date,yyyy-MM}                     -> 2024-07 (flat structure)
+  #pattern = "${date,yyyy}/${date,MM}"
+}

--- a/core/src/main/java/sk/kubisoft/exifutils/core/config/ConfigService.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/config/ConfigService.java
@@ -62,4 +62,8 @@ public class ConfigService {
 		return config.getString("rename.pattern");
 	}
 
+	public String getSortPattern() {
+		return config.getString("sort.pattern");
+	}
+
 }

--- a/core/src/main/java/sk/kubisoft/exifutils/core/file/FileMover.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/file/FileMover.java
@@ -25,6 +25,16 @@ public class FileMover {
     }
 
     public void moveFiles(List<MoveAction> moveActions) {
+        processFiles(moveActions, false);
+    }
+
+    public void copyFiles(List<MoveAction> moveActions) {
+        processFiles(moveActions, true);
+    }
+
+    private void processFiles(List<MoveAction> moveActions, boolean copy) {
+        String operation = copy ? "copy" : "move";
+        String operationPast = copy ? "copied" : "moved";
         int successCount = 0;
 
         for (var action : moveActions) {
@@ -52,8 +62,8 @@ public class FileMover {
                     continue;
                 }
 
-                // Rest of the existing move logic...
-                if (!Files.isWritable(source)) {
+                // Check source is writable only for move operations
+                if (!copy && !Files.isWritable(source)) {
                     console.errorln("Source file is not writable: %s", source);
                     continue;
                 }
@@ -68,28 +78,35 @@ public class FileMover {
                     continue;
                 }
 
-                console.println("Moving %s", action);
-                // Perform atomic move
-                try {
-                    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+                if (copy) {
+                    console.println("Copying %s", action);
+                    Files.copy(source, target);
                     successCount++;
-                    logger.debug("Successfully moved {} to {}", source, target);
-                } catch (AtomicMoveNotSupportedException e) {
-                    // Fallback to non-atomic move if atomic is not supported
-                    Files.move(source, target);
-                    successCount++;
-                    logger.debug("Successfully moved (non-atomic) {} to {}", source, target);
+                    logger.debug("Successfully copied {} to {}", source, target);
+                } else {
+                    console.println("Moving %s", action);
+                    // Perform atomic move
+                    try {
+                        Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+                        successCount++;
+                        logger.debug("Successfully moved {} to {}", source, target);
+                    } catch (AtomicMoveNotSupportedException e) {
+                        // Fallback to non-atomic move if atomic is not supported
+                        Files.move(source, target);
+                        successCount++;
+                        logger.debug("Successfully moved (non-atomic) {} to {}", source, target);
+                    }
                 }
             } catch (SecurityException e) {
-                console.errorln("Security violation moving %s to %s: %s", source, target, e.getMessage());
+                console.errorln("Security violation %s %s to %s: %s", operation, source, target, e.getMessage());
             } catch (IOException e) {
-                console.errorln("IO error moving %s to %s: %s", source, target, e.getMessage());
+                console.errorln("IO error %s %s to %s: %s", operation, source, target, e.getMessage());
             } catch (Exception e) {
-                console.errorln("Unexpected error moving %s to %s: %s", source, target, e.getMessage());
+                console.errorln("Unexpected error %s %s to %s: %s", operation, source, target, e.getMessage());
             }
         }
 
-        console.println("Operation completed. Successfully moved %s out of %s files",
-                successCount, moveActions.size());
+        console.println("Operation completed. Successfully %s %s out of %s files",
+                operationPast, successCount, moveActions.size());
     }
 }

--- a/core/src/main/java/sk/kubisoft/exifutils/core/file/FileMover.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/file/FileMover.java
@@ -33,8 +33,6 @@ public class FileMover {
     }
 
     private void processFiles(List<MoveAction> moveActions, boolean copy) {
-        String operation = copy ? "copy" : "move";
-        String operationPast = copy ? "copied" : "moved";
         int successCount = 0;
 
         for (var action : moveActions) {
@@ -98,15 +96,15 @@ public class FileMover {
                     }
                 }
             } catch (SecurityException e) {
-                console.errorln("Security violation %s %s to %s: %s", operation, source, target, e.getMessage());
+                console.errorln("Security violation %s %s to %s: %s", copy ? "copying" : "moving", source, target, e.getMessage());
             } catch (IOException e) {
-                console.errorln("IO error %s %s to %s: %s", operation, source, target, e.getMessage());
+                console.errorln("IO error %s %s to %s: %s", copy ? "copying" : "moving", source, target, e.getMessage());
             } catch (Exception e) {
-                console.errorln("Unexpected error %s %s to %s: %s", operation, source, target, e.getMessage());
+                console.errorln("Unexpected error %s %s to %s: %s", copy ? "copying" : "moving", source, target, e.getMessage());
             }
         }
 
         console.println("Operation completed. Successfully %s %s out of %s files",
-                operationPast, successCount, moveActions.size());
+                copy ? "copied" : "moved", successCount, moveActions.size());
     }
 }

--- a/core/src/main/java/sk/kubisoft/exifutils/core/media/MediaFileNameUtils.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/media/MediaFileNameUtils.java
@@ -2,15 +2,13 @@ package sk.kubisoft.exifutils.core.media;
 
 import org.apache.commons.lang3.StringUtils;
 import sk.kubisoft.exifutils.core.config.ConfigService;
+import sk.kubisoft.exifutils.core.utils.DatePatternResolver;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.apache.commons.io.FilenameUtils.getExtension;
 
@@ -29,16 +27,8 @@ public class MediaFileNameUtils {
         var mediaDate = mediaFile.getCreationDate();
         LocalDateTime dateTime = mediaDate.getLocalDateTime();
 
-        // Find all ${date,format} patterns
-        Matcher dateMatcher = Pattern.compile("\\$\\{date,([^}]+)}").matcher(result);
-        StringBuilder sb = new StringBuilder();
-        while (dateMatcher.find()) {
-            String format = dateMatcher.group(1);
-            String formatted = dateTime.format(DateTimeFormatter.ofPattern(format));
-            dateMatcher.appendReplacement(sb, formatted);
-        }
-        dateMatcher.appendTail(sb);
-        result = sb.toString();
+        // Resolve ${date,format} patterns
+        result = DatePatternResolver.resolve(result, dateTime);
 
         // Replace other variables
         Map<String, String> replacements = new HashMap<>();

--- a/core/src/main/java/sk/kubisoft/exifutils/core/utils/DatePatternResolver.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/utils/DatePatternResolver.java
@@ -1,0 +1,42 @@
+package sk.kubisoft.exifutils.core.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves date patterns in strings using the ${date,FORMAT} syntax.
+ * The FORMAT follows Java's DateTimeFormatter pattern specifications.
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html">DateTimeFormatter</a>
+ */
+public final class DatePatternResolver {
+
+    private static final Pattern DATE_PATTERN = Pattern.compile("\\$\\{date,([^}]+)}");
+
+    private DatePatternResolver() {
+        // Utility class
+    }
+
+    /**
+     * Resolves all ${date,FORMAT} patterns in the input string using the provided date.
+     *
+     * @param pattern the pattern string containing ${date,FORMAT} placeholders
+     * @param dateTime the date to use for formatting
+     * @return the resolved string with all date placeholders replaced
+     */
+    public static String resolve(String pattern, LocalDateTime dateTime) {
+        Matcher matcher = DATE_PATTERN.matcher(pattern);
+        StringBuilder result = new StringBuilder();
+
+        while (matcher.find()) {
+            String format = matcher.group(1);
+            String formatted = dateTime.format(DateTimeFormatter.ofPattern(format));
+            matcher.appendReplacement(result, Matcher.quoteReplacement(formatted));
+        }
+        matcher.appendTail(result);
+
+        return result.toString();
+    }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -13,3 +13,16 @@ rename {
   #          specs: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html
   pattern = "IMG_${date,yyyyMMdd}_${date,HHmmss}"
 }
+
+sort {
+  # Pattern for folder structure when sorting files by date.
+  # Uses ${date,FORMAT} syntax with Java DateTimeFormatter patterns.
+  # Specs: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html
+  #
+  # Examples:
+  #   ${date,yyyy}/${date,MM}           -> 2024/07 (default: year/month)
+  #   ${date,yyyy}/${date,MM}/${date,dd} -> 2024/07/15 (year/month/day)
+  #   ${date,yyyy}/${date,ww}           -> 2024/28 (year/week of year)
+  #   ${date,yyyy-MM}                   -> 2024-07 (flat year-month)
+  pattern = "${date,yyyy}/${date,MM}"
+}

--- a/core/src/test/java/sk/kubisoft/exifutils/core/utils/DatePatternResolverTest.java
+++ b/core/src/test/java/sk/kubisoft/exifutils/core/utils/DatePatternResolverTest.java
@@ -1,0 +1,73 @@
+package sk.kubisoft.exifutils.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatePatternResolverTest {
+
+    private static final LocalDateTime TEST_DATE = LocalDateTime.of(2024, 7, 15, 10, 30, 45);
+
+    @Test
+    void testYearMonthPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy}/${date,MM}", TEST_DATE);
+        assertEquals("2024/07", result);
+    }
+
+    @Test
+    void testYearMonthDayPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy}/${date,MM}/${date,dd}", TEST_DATE);
+        assertEquals("2024/07/15", result);
+    }
+
+    @Test
+    void testWeekOfYearPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy}/${date,ww}", TEST_DATE);
+        assertEquals("2024/29", result);
+    }
+
+    @Test
+    void testFlatYearMonthPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy-MM}", TEST_DATE);
+        assertEquals("2024-07", result);
+    }
+
+    @Test
+    void testComplexPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy}/${date,MM}/${date,dd}_${date,HHmmss}", TEST_DATE);
+        assertEquals("2024/07/15_103045", result);
+    }
+
+    @Test
+    void testPatternWithLiteralText() {
+        String result = DatePatternResolver.resolve("photos/${date,yyyy}/month_${date,MM}", TEST_DATE);
+        assertEquals("photos/2024/month_07", result);
+    }
+
+    @Test
+    void testSingleDigitMonth() {
+        LocalDateTime januaryDate = LocalDateTime.of(2024, 1, 5, 10, 30);
+        String result = DatePatternResolver.resolve("${date,yyyy}/${date,MM}", januaryDate);
+        assertEquals("2024/01", result);
+    }
+
+    @Test
+    void testQuarterPattern() {
+        String result = DatePatternResolver.resolve("${date,yyyy}/Q${date,Q}", TEST_DATE);
+        assertEquals("2024/Q3", result);
+    }
+
+    @Test
+    void testNoPatternPlaceholders() {
+        String result = DatePatternResolver.resolve("static/path", TEST_DATE);
+        assertEquals("static/path", result);
+    }
+
+    @Test
+    void testEmptyPattern() {
+        String result = DatePatternResolver.resolve("", TEST_DATE);
+        assertEquals("", result);
+    }
+}

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/MediaFileSorter.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/MediaFileSorter.java
@@ -1,10 +1,12 @@
 package sk.kubisoft.exifutils.sort;
 
+import sk.kubisoft.exifutils.core.config.ConfigService;
 import sk.kubisoft.exifutils.core.file.MoveAction;
 import sk.kubisoft.exifutils.core.file.conflict.DuplicatePreProcessor;
 import sk.kubisoft.exifutils.core.media.AnalyzedMediaFile;
 import sk.kubisoft.exifutils.core.media.MediaDateTime;
 import sk.kubisoft.exifutils.core.media.MediaFileNameUtils;
+import sk.kubisoft.exifutils.core.utils.DatePatternResolver;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -19,13 +21,19 @@ public class MediaFileSorter {
 
     private final DuplicatePreProcessor duplicatePreProcessor;
 
+    private final ConfigService configService;
+
     @Inject
-    public MediaFileSorter(MediaFileNameUtils fileNameUtils, DuplicatePreProcessor duplicatePreProcessor) {
+    public MediaFileSorter(MediaFileNameUtils fileNameUtils, DuplicatePreProcessor duplicatePreProcessor,
+                           ConfigService configService) {
         this.fileNameUtils = fileNameUtils;
         this.duplicatePreProcessor = duplicatePreProcessor;
+        this.configService = configService;
     }
 
-    public List<MoveAction> sort(List<AnalyzedMediaFile> mediaFiles, Path targetRootPath, boolean rename) {
+    public List<MoveAction> sort(List<AnalyzedMediaFile> mediaFiles, Path targetRootPath, boolean rename,
+                                 String sortPattern) {
+        var effectivePattern = sortPattern != null ? sortPattern : configService.getSortPattern();
         var moveActions = new ArrayList<MoveAction>();
 
         for (var mediaFile : mediaFiles) {
@@ -38,7 +46,7 @@ public class MediaFileSorter {
             } else {
                 targetFileName = originalFileName;
             }
-            var targetDateFolder = createTargetDateFolder(mediaFile.getCreationDate());
+            var targetDateFolder = createTargetDateFolder(mediaFile.getCreationDate(), effectivePattern);
             var finalTargetPath = targetRootPath.resolve(targetDateFolder).resolve(targetFileName);
 
             moveActions.add(new MoveAction(originalPath, finalTargetPath));
@@ -48,14 +56,10 @@ public class MediaFileSorter {
         return duplicatePreProcessor.processConflicts(moveActions);
     }
 
-    private Path createTargetDateFolder(MediaDateTime date) {
-        var localDate = date.getLocalDateTime();
-
-        var year = String.valueOf(localDate.getYear());
-        var month = String.valueOf(localDate.getMonthValue());
-        var paddedMonth = month.length() == 1 ? "0" + month : month;
-
-        return Path.of(year, paddedMonth);
+    private Path createTargetDateFolder(MediaDateTime date, String pattern) {
+        var localDateTime = date.getLocalDateTime();
+        String resolved = DatePatternResolver.resolve(pattern, localDateTime);
+        return Path.of(resolved);
     }
 
 }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
@@ -84,12 +84,19 @@ public class SortCommand {
             console.println("No files to move.");
         }
 
-        console.println("Total %d files will be moved:", moveActions.size());
-        moveActions.forEach((moveAction) -> console.println("Move %s", moveAction));
+        String operation = input.copy() ? "copied" : "moved";
+        console.println("Total %d files will be %s:", moveActions.size(), operation);
+        moveActions.forEach((moveAction) -> console.println("%s %s",
+                input.copy() ? "Copy" : "Move", moveAction));
 
         if (console.confirmAction("Do you want to continue?")) {
-            console.println("Moving files...");
-            fileMover.moveFiles(moveActions);
+            if (input.copy()) {
+                console.println("Copying files...");
+                fileMover.copyFiles(moveActions);
+            } else {
+                console.println("Moving files...");
+                fileMover.moveFiles(moveActions);
+            }
         } else {
             console.println("Aborted.");
         }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
@@ -84,10 +84,8 @@ public class SortCommand {
             console.println("No files to move.");
         }
 
-        String operation = input.copy() ? "copied" : "moved";
-        console.println("Total %d files will be %s:", moveActions.size(), operation);
-        moveActions.forEach((moveAction) -> console.println("%s %s",
-                input.copy() ? "Copy" : "Move", moveAction));
+        console.println("Total %d files will be %s:", moveActions.size(), input.copy() ? "copied" : "moved");
+        moveActions.forEach((moveAction) -> console.println("%s %s", input.copy() ? "Copy" : "Move", moveAction));
 
         if (console.confirmAction("Do you want to continue?")) {
             if (input.copy()) {

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
@@ -77,7 +77,8 @@ public class SortCommand {
             }
         }
 
-        List<MoveAction> moveActions = mediaFileSorter.sort(mediaFilesWithDate, input.outputDir(), input.rename());
+        List<MoveAction> moveActions = mediaFileSorter.sort(mediaFilesWithDate, input.outputDir(), input.rename(),
+                input.sortPattern());
 
         if (moveActions.isEmpty()) {
             console.println("No files to move.");

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
@@ -16,7 +16,13 @@ public record SortCommandInput(
          * Custom sort pattern using ${date,FORMAT} syntax.
          * If null, the default pattern from configuration is used.
          */
-        String sortPattern
+        String sortPattern,
+
+        /**
+         * If true, copy files instead of moving them.
+         * Useful for experimenting with sort patterns.
+         */
+        boolean copy
 
 ) {
 }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
@@ -10,7 +10,13 @@ public record SortCommandInput(
 
         boolean rename,
 
-        boolean writeDate
+        boolean writeDate,
+
+        /**
+         * Custom sort pattern using ${date,FORMAT} syntax.
+         * If null, the default pattern from configuration is used.
+         */
+        String sortPattern
 
 ) {
 }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
@@ -38,6 +38,12 @@ public class SortCommandRunner implements CommandRunner {
             .desc("Write analyzed date to file metadata.")
             .build();
 
+    private static final Option PATTERN = Option.builder()
+            .option("p").hasArg()
+            .longOpt("pattern").hasArg().argName("PATTERN")
+            .desc("Custom folder pattern using ${date,FORMAT} syntax (e.g., ${date,yyyy}/${date,MM}/${date,dd}).")
+            .build();
+
     private final SortCommand sortCommand;
 
     private final Console console;
@@ -87,7 +93,9 @@ public class SortCommandRunner implements CommandRunner {
 
         boolean writeDate = cmd.hasOption(WRITE.getOpt());
 
-        return new SortCommandInput(args, outputDir, renameFiles, writeDate);
+        String sortPattern = cmd.getOptionValue(PATTERN.getOpt());
+
+        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern);
     }
 
     @Override
@@ -106,6 +114,7 @@ public class SortCommandRunner implements CommandRunner {
         options.addOption(OUTPUT_DIR);
         options.addOption(RENAME);
         options.addOption(WRITE);
+        options.addOption(PATTERN);
         return options;
     }
 

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
@@ -44,6 +44,12 @@ public class SortCommandRunner implements CommandRunner {
             .desc("Custom folder pattern using ${date,FORMAT} syntax (e.g., ${date,yyyy}/${date,MM}/${date,dd}).")
             .build();
 
+    private static final Option COPY = Option.builder()
+            .option("c")
+            .longOpt("copy")
+            .desc("Copy files instead of moving them (useful for experimenting with patterns).")
+            .build();
+
     private final SortCommand sortCommand;
 
     private final Console console;
@@ -95,7 +101,9 @@ public class SortCommandRunner implements CommandRunner {
 
         String sortPattern = cmd.getOptionValue(PATTERN.getOpt());
 
-        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern);
+        boolean copyFiles = cmd.hasOption(COPY.getOpt());
+
+        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern, copyFiles);
     }
 
     @Override
@@ -115,6 +123,7 @@ public class SortCommandRunner implements CommandRunner {
         options.addOption(RENAME);
         options.addOption(WRITE);
         options.addOption(PATTERN);
+        options.addOption(COPY);
         return options;
     }
 

--- a/sort/src/test/java/sk/kubisoft/exifutils/sort/MediaFileSorterTest.java
+++ b/sort/src/test/java/sk/kubisoft/exifutils/sort/MediaFileSorterTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import sk.kubisoft.exifutils.core.config.ConfigService;
 import sk.kubisoft.exifutils.core.file.MoveAction;
 import sk.kubisoft.exifutils.core.file.conflict.DuplicatePreProcessor;
 import sk.kubisoft.exifutils.core.media.AnalyzedMediaFile;
@@ -23,13 +26,19 @@ import static org.mockito.Mockito.when;
 import static sk.kubisoft.exifutils.core.media.MediaType.IMAGE;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MediaFileSorterTest {
+
+    private static final String DEFAULT_PATTERN = "${date,yyyy}/${date,MM}";
 
     @Mock
     private MediaFileNameUtils fileNameUtils;
 
     @Mock
     private DuplicatePreProcessor duplicatePreProcessor;
+
+    @Mock
+    private ConfigService configService;
 
     private MediaFileSorter sorter;
     private Path sourceRoot;
@@ -40,8 +49,9 @@ class MediaFileSorterTest {
         when(duplicatePreProcessor.processConflicts(anyList()))
                 // Return the same list of actions without any processing for this test
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        when(configService.getSortPattern()).thenReturn(DEFAULT_PATTERN);
 
-        sorter = new MediaFileSorter(fileNameUtils, duplicatePreProcessor);
+        sorter = new MediaFileSorter(fileNameUtils, duplicatePreProcessor, configService);
         sourceRoot = Path.of("/source");
         targetRoot = Path.of("/target");
     }
@@ -52,8 +62,8 @@ class MediaFileSorterTest {
         var mediaFile = new AnalyzedMediaFile(sourceRoot.resolve("IMG7277.JPG"), IMAGE, emptyMap(),
                 mediaDateTime(LocalDateTime.of(2024, 7, 15, 10, 30)));
 
-        // When
-        List<MoveAction> result = sorter.sort(List.of(mediaFile), targetRoot, false);
+        // When - null pattern uses default from config
+        List<MoveAction> result = sorter.sort(List.of(mediaFile), targetRoot, false, null);
 
         // Then
         assertEquals(1, result.size());
@@ -71,7 +81,7 @@ class MediaFileSorterTest {
                 mediaDateTime(LocalDateTime.of(2024, 7, 15, 10, 30)));
 
         // When
-        List<MoveAction> result = sorter.sort(List.of(file1, file2), targetRoot, false);
+        List<MoveAction> result = sorter.sort(List.of(file1, file2), targetRoot, false, null);
 
         // Then
         assertEquals(2, result.size());
@@ -92,7 +102,7 @@ class MediaFileSorterTest {
                 mediaDateTime(LocalDateTime.of(2024, 8, 1, 10, 30)));
 
         // When
-        List<MoveAction> result = sorter.sort(List.of(julyFile, augustFile), targetRoot, false);
+        List<MoveAction> result = sorter.sort(List.of(julyFile, augustFile), targetRoot, false, null);
 
         // Then
         assertEquals(2, result.size());
@@ -113,7 +123,7 @@ class MediaFileSorterTest {
                 mediaDateTime(LocalDateTime.of(2023, 12, 31, 23, 59)));
 
         // When
-        List<MoveAction> result = sorter.sort(List.of(file2024, file2023), targetRoot, false);
+        List<MoveAction> result = sorter.sort(List.of(file2024, file2023), targetRoot, false, null);
 
         // Then
         assertEquals(2, result.size());
@@ -132,12 +142,57 @@ class MediaFileSorterTest {
                 mediaDateTime(LocalDateTime.of(2024, 1, 15, 12, 34, 56)));
 
         // When
-        List<MoveAction> result = sorter.sort(List.of(complexFileName), targetRoot, false);
+        List<MoveAction> result = sorter.sort(List.of(complexFileName), targetRoot, false, null);
 
         // Then
         var moveAction = result.getFirst();
         assertEquals(sourceRoot.resolve("IMG_20240115_123456_HDR.jpg"), moveAction.source());
         assertEquals(targetRoot.resolve("2024/01/IMG_20240115_123456_HDR.jpg"), moveAction.target());
+    }
+
+    @Test
+    void testCustomPatternOverridesDefault() {
+        // Given
+        var mediaFile = new AnalyzedMediaFile(sourceRoot.resolve("IMG7277.JPG"), IMAGE, emptyMap(),
+                mediaDateTime(LocalDateTime.of(2024, 7, 15, 10, 30)));
+        String customPattern = "${date,yyyy}/${date,MM}/${date,dd}";
+
+        // When - custom pattern is provided
+        List<MoveAction> result = sorter.sort(List.of(mediaFile), targetRoot, false, customPattern);
+
+        // Then
+        var moveAction = result.getFirst();
+        assertEquals(targetRoot.resolve("2024/07/15/IMG7277.JPG"), moveAction.target());
+    }
+
+    @Test
+    void testFlatPatternStructure() {
+        // Given
+        var mediaFile = new AnalyzedMediaFile(sourceRoot.resolve("IMG7277.JPG"), IMAGE, emptyMap(),
+                mediaDateTime(LocalDateTime.of(2024, 7, 15, 10, 30)));
+        String flatPattern = "${date,yyyy-MM}";
+
+        // When
+        List<MoveAction> result = sorter.sort(List.of(mediaFile), targetRoot, false, flatPattern);
+
+        // Then
+        var moveAction = result.getFirst();
+        assertEquals(targetRoot.resolve("2024-07/IMG7277.JPG"), moveAction.target());
+    }
+
+    @Test
+    void testWeekBasedPattern() {
+        // Given
+        var mediaFile = new AnalyzedMediaFile(sourceRoot.resolve("IMG7277.JPG"), IMAGE, emptyMap(),
+                mediaDateTime(LocalDateTime.of(2024, 7, 15, 10, 30)));
+        String weekPattern = "${date,yyyy}/W${date,ww}";
+
+        // When
+        List<MoveAction> result = sorter.sort(List.of(mediaFile), targetRoot, false, weekPattern);
+
+        // Then
+        var moveAction = result.getFirst();
+        assertEquals(targetRoot.resolve("2024/W29/IMG7277.JPG"), moveAction.target());
     }
 
     private MediaDateTime mediaDateTime(LocalDateTime localDateTime) {


### PR DESCRIPTION
## Summary

- Add `sort.pattern` configuration with `${date,FORMAT}` syntax using Java's DateTimeFormatter
- Add `-p/--pattern` CLI option to override the default pattern on command line
- Create `DatePatternResolver` utility for shared pattern resolution
- Refactor `MediaFileNameUtils` to use the shared utility
- Document all settings in README.md with examples

## Pattern Examples

| Pattern | Output | Description |
|---------|--------|-------------|
| `${date,yyyy}/${date,MM}` | `2024/07` | Year/month (default) |
| `${date,yyyy}/${date,MM}/${date,dd}` | `2024/07/15` | Year/month/day |
| `${date,yyyy}/${date,ww}` | `2024/29` | Year/week of year |
| `${date,yyyy-MM}` | `2024-07` | Flat year-month |
| `${date,yyyy}/Q${date,Q}` | `2024/Q3` | Year/quarter |

## Usage

```bash
# Use default pattern from config (year/month)
exifutils sort -o /output /input

# Override with custom pattern (year/month/day)
exifutils sort -o /output -p '${date,yyyy}/${date,MM}/${date,dd}' /input
```

## Test plan

- [x] Unit tests for `DatePatternResolver` covering various patterns
- [x] Unit tests for `MediaFileSorter` with custom patterns
- [x] All existing tests pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)