### PR TITLE
feat: add --force-field CLI option for date extraction override

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,42 @@ Logs are written to `exifutils.log` and rolled daily or when reaching 10MB. Old 
 
 ## Commands
 
+### Common Options
+
+The following option is available across multiple commands that analyze media files:
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--force-field` | `-F` | Force date extraction from a specific EXIF field, bypassing device profiles |
+
+#### Force Field Option (`-F`, `--force-field`)
+
+By default, exifutils uses device-specific profiles to determine which EXIF fields to read for date extraction. The `--force-field` option overrides this behavior and extracts the date from a specific field you specify.
+
+**Available in:** `rename`, `sort`, `set-date`, `shift-date`
+
+**Use cases:**
+- Old video files (e.g., `.MPG`) that lack standard EXIF metadata but have accurate filesystem dates
+- Files where the standard date fields are incorrect but another field contains the correct date
+- Special cases where you need to use a non-standard date field
+
+**Example:**
+```bash
+# Use filesystem modification date for renaming old MPG files
+exifutils rename --force-field FileModifyDate /path/to/old-videos/
+
+# Sort files using a specific metadata field
+exifutils sort -F CreateDate -o /output /input
+
+# List all available fields for a file
+exifutils info -a photo.jpg
+```
+
+**Behavior:**
+- If the specified field exists, its value is used as the creation date
+- If the field doesn't exist or can't be parsed, no date is returned for that file
+- Timezone resolution still applies (GPS fallback, then config default)
+
 ### info
 
 Prints extracted metadata information for given files.
@@ -147,6 +183,7 @@ Sets the creation date in EXIF metadata of media files. This command supports mu
 | `--zone-id` | `-z` | Set timezone ID (e.g., `Europe/Paris`). Falls back to config default if not specified |
 | `--pattern` | `-p` | Parse date from filename using custom DateTimeFormatter pattern |
 | `--fix-zone` | `-f` | Fix timezone using existing EXIF local date/time |
+| `--force-field` | `-F` | Force date extraction from a specific EXIF field (see [Common Options](#common-options)) |
 | `--rename` | `-r` | Rename files after setting date |
 | `--unknown` | `-u` | Only process files with unknown/missing dates |
 

--- a/core/src/main/java/sk/kubisoft/exifutils/core/analysis/ExifDateExtractor.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/analysis/ExifDateExtractor.java
@@ -35,6 +35,14 @@ public class ExifDateExtractor {
     }
 
     public Optional<ExifDateTime> extractCreationDate(MediaType mediaType, Map<String, String> metadata) {
+        return extractCreationDate(mediaType, metadata, null);
+    }
+
+    public Optional<ExifDateTime> extractCreationDate(MediaType mediaType, Map<String, String> metadata, String forceField) {
+        if (StringUtils.isNotBlank(forceField)) {
+            return extractFromForcedField(metadata, forceField);
+        }
+
 		DeviceProfile deviceProfile = deviceProfileService.getProfileForTags(metadata);
 		console.verboseln("Using device profile: %s", deviceProfile.getName());
 
@@ -73,6 +81,31 @@ public class ExifDateExtractor {
 			console.verboseln("No valid date found in EXIF tags");
 			return Optional.empty();
 		}
+    }
+
+    private Optional<ExifDateTime> extractFromForcedField(Map<String, String> metadata, String forceField) {
+        console.verboseln("Using forced field: %s", forceField);
+        String dateStr = metadata.get(forceField);
+
+        if (StringUtils.isBlank(dateStr)) {
+            console.verboseln("No value found in forced field: %s", forceField);
+            return Optional.empty();
+        }
+
+        try {
+            // Parse as local time with no offset field - timezone resolution will be handled by MediaAnalyzer
+            var exifDateTimeOptional = exifDateParser.parseExifDate(dateStr, true, null);
+            if (exifDateTimeOptional.isPresent()) {
+                console.verboseln("Found date in forced field %s: %s", forceField, exifDateTimeOptional.get());
+                return exifDateTimeOptional;
+            }
+        } catch (DateTimeParseException e) {
+            logger.warn("Could not parse date from forced field {}: '{}': {}", forceField, dateStr, e.getMessage());
+        } catch (Exception e) {
+            logger.error("Error parsing date from forced field {}: {}", forceField, dateStr, e);
+        }
+
+        return Optional.empty();
     }
 
 }

--- a/core/src/main/java/sk/kubisoft/exifutils/core/analysis/MediaAnalyzer.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/analysis/MediaAnalyzer.java
@@ -44,6 +44,10 @@ public class MediaAnalyzer {
 	}
 
 	public List<AnalyzedMediaFile> analyze(List<MediaFile> files) {
+		return analyze(files, null);
+	}
+
+	public List<AnalyzedMediaFile> analyze(List<MediaFile> files, String forceField) {
 		List<AnalyzedMediaFile> analyzedFiles = new ArrayList<>();
 		console.println("Starting analysis of media files...", files.size());
 		try (var metaDataHandler = metaDataHandlerFactory.create()) {
@@ -58,7 +62,7 @@ public class MediaAnalyzer {
 				}
 
 				try {
-					AnalyzedMediaFile mediaFile = analyze(file, metaDataHandler, gpsZoneExtractor);
+					AnalyzedMediaFile mediaFile = analyze(file, metaDataHandler, gpsZoneExtractor, forceField);
 					analyzedFiles.add(mediaFile);
 				} catch (Exception e) {
 					console.error("Error processing file: %s", e, path);
@@ -77,9 +81,9 @@ public class MediaAnalyzer {
 		return analyzedFiles;
 	}
 
-	private AnalyzedMediaFile analyze(MediaFile mediaFile, MetaDataHandler metaDataHandler, GpsZoneExtractor gpsZoneExtractor) {
+	private AnalyzedMediaFile analyze(MediaFile mediaFile, MetaDataHandler metaDataHandler, GpsZoneExtractor gpsZoneExtractor, String forceField) {
 		Map<String, String> metadata = metaDataHandler.extractMetaData(mediaFile.getOriginalPath());
-		Optional<ExifDateTime> extractedDateOptional = exifDateExtractor.extractCreationDate(mediaFile.getMediaType(), metadata);
+		Optional<ExifDateTime> extractedDateOptional = exifDateExtractor.extractCreationDate(mediaFile.getMediaType(), metadata, forceField);
 		if (extractedDateOptional.isEmpty()) {
 			console.verboseln("No date found in metadata");
 			return new AnalyzedMediaFile(mediaFile.getOriginalPath(), mediaFile.getMediaType(), metadata, null);

--- a/core/src/test/java/sk/kubisoft/exifutils/core/analysis/ExifDateExtractorTest.java
+++ b/core/src/test/java/sk/kubisoft/exifutils/core/analysis/ExifDateExtractorTest.java
@@ -257,8 +257,67 @@ class ExifDateExtractorTest {
 		assertThat(exifDateTime.zoneOffset()).isNull();
     }
 
+    @Test
+    void extractDateTimeUsingForceField() {
+        // Using forceField to extract from a specific field (ModifyDate instead of DateTimeOriginal)
+        Map<String, String> metaData = loadMetaData("/exifdata/image_2.txt");
+
+        var exifDateTime = extractWithForceField(IMAGE, metaData, "ModifyDate");
+
+        assertThat(exifDateTime).isNotNull();
+        assertThat(exifDateTime.localDateTime()).hasToString("2023-08-31T18:11:44");
+        assertThat(exifDateTime.localTime()).isTrue();
+        // forceField parses without offset field, so offset should be null
+        assertThat(exifDateTime.zoneOffset()).isNull();
+    }
+
+    @Test
+    void extractDateTimeUsingForceFieldNonExistent() {
+        // Using forceField with a field that does not exist
+        Map<String, String> metaData = loadMetaData("/exifdata/image_2.txt");
+
+        var exifDateTime = extractWithForceField(IMAGE, metaData, "NonExistentField");
+
+        assertThat(exifDateTime).isNull();
+    }
+
+    @Test
+    void extractDateTimeUsingForceFieldFromFileModifyDate() {
+        // Using forceField to extract from FileModifyDate
+        // This tests the use case mentioned in the issue - using filesystem dates
+        Map<String, String> metaData = loadMetaData("/exifdata/image_2.txt");
+
+        var exifDateTime = extractWithForceField(IMAGE, metaData, "FileModifyDate");
+
+        assertThat(exifDateTime).isNotNull();
+        // FileModifyDate: 2025:01:04 15:55:52+01:00 - parsed as local time
+        assertThat(exifDateTime.localDateTime()).hasToString("2025-01-04T15:55:52");
+        assertThat(exifDateTime.localTime()).isTrue();
+        // Offset is embedded in the date string and should be parsed
+        assertThat(exifDateTime.zoneOffset()).hasToString("+01:00");
+    }
+
+    @Test
+    void extractDateTimeUsingForceFieldForImageWithNoDate() {
+        // Using forceField on an image that normally has no date
+        Map<String, String> metaData = loadMetaData("/exifdata/image_1.txt");
+
+        // Normal extraction should return null
+        var normalExifDateTime = extract(IMAGE, metaData);
+        assertThat(normalExifDateTime).isNull();
+
+        // forceField should also return null if the field doesn't exist
+        var forcedExifDateTime = extractWithForceField(IMAGE, metaData, "DateTimeOriginal");
+        assertThat(forcedExifDateTime).isNull();
+    }
+
     private ExifDateTime extract(MediaType mediaType, Map<String, String> metadata) {
         return exifDateExtractor.extractCreationDate(mediaType, metadata)
+                .orElse(null);
+    }
+
+    private ExifDateTime extractWithForceField(MediaType mediaType, Map<String, String> metadata, String forceField) {
+        return exifDateExtractor.extractCreationDate(mediaType, metadata, forceField)
                 .orElse(null);
     }
 

--- a/core/src/test/java/sk/kubisoft/exifutils/core/analysis/MediaAnalyzerTest.java
+++ b/core/src/test/java/sk/kubisoft/exifutils/core/analysis/MediaAnalyzerTest.java
@@ -184,7 +184,7 @@ class MediaAnalyzerTest {
     private MediaDateTime analyze(MediaType mediaType, LocalDateTime localDateTime, boolean localTime,
 								  ZoneOffset zoneOffset, ZoneOffset gpsResolvedZoneOffset) {
 		if (localDateTime != null) {
-			when(exifDateExtractorMock.extractCreationDate(any(), any()))
+			when(exifDateExtractorMock.extractCreationDate(any(), any(), any()))
 					.thenReturn(Optional.of(new ExifDateTime(localDateTime, localTime, zoneOffset)));
 		}
         when(metaDataHandlerFactoryMock.create())

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommand.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommand.java
@@ -55,7 +55,7 @@ public class RenameCommand {
         List<MediaFile> mediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
         console.println("Found %d files.", mediaFiles.size());
 
-        List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(mediaFiles);
+        List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(mediaFiles, input.forceField());
 
         List<AnalyzedMediaFile> mediaFilesWithDate = analyzedFiles.stream()
                 .filter(mediaFile -> mediaFile.getCreationDate() != null)

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandInput.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandInput.java
@@ -11,7 +11,9 @@ public record RenameCommandInput(
 
         boolean writeDate,
 
-        ZoneId zoneId
+        ZoneId zoneId,
+
+        String forceField
 
 ) {
 }

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandRunner.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandRunner.java
@@ -37,6 +37,13 @@ public class RenameCommandRunner implements CommandRunner {
             .hasArg()
             .build();
 
+    private static final Option FORCE_FIELD = Option.builder()
+            .option("F")
+            .longOpt("force-field")
+            .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
     private final Console console;
 
     private final RenameCommand renameCommand;
@@ -89,7 +96,9 @@ public class RenameCommandRunner implements CommandRunner {
             }
         }
 
-        return new RenameCommandInput(args, outputDir, writeDate, zoneId);
+        String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
+
+        return new RenameCommandInput(args, outputDir, writeDate, zoneId, forceField);
     }
 
     @Override
@@ -108,6 +117,7 @@ public class RenameCommandRunner implements CommandRunner {
         options.addOption(WRITE);
         options.addOption(ZONE_ID);
         options.addOption(OUTPUT_DIR);
+        options.addOption(FORCE_FIELD);
         return options;
     }
 

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommand.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommand.java
@@ -63,7 +63,7 @@ public class SetDateCommand {
 
         List<MediaFile> mediaFiles;
         if (input.unknownOnly()) {
-            var analyzedMediaFiles = mediaAnalyzer.analyze(allMediaFiles);
+            var analyzedMediaFiles = mediaAnalyzer.analyze(allMediaFiles, input.forceField());
 
             mediaFiles = analyzedMediaFiles.stream()
                     .filter(mediaFile -> mediaFile.getCreationDate() == null)
@@ -75,7 +75,7 @@ public class SetDateCommand {
 
         List<SetDateAction> setDateActionList;
         if (input.fixZone()) {
-            setDateActionList = fixTimeZone(mediaFiles, input.zoneId());
+            setDateActionList = fixTimeZone(mediaFiles, input.zoneId(), input.forceField());
         } else if (input.localDateTime() != null) {
             setDateActionList = setDateTimeManually(mediaFiles, input.localDateTime(), input.zoneId());
         } else {
@@ -177,10 +177,10 @@ public class SetDateCommand {
         return actions;
     }
 
-    private List<SetDateAction> fixTimeZone(List<MediaFile> mediaFiles, ZoneId zoneId) {
+    private List<SetDateAction> fixTimeZone(List<MediaFile> mediaFiles, ZoneId zoneId, String forceField) {
         console.println("Fixing timezone for files using existing EXIF local date/time");
 
-        var analyzedFiles = mediaAnalyzer.analyze(mediaFiles);
+        var analyzedFiles = mediaAnalyzer.analyze(mediaFiles, forceField);
         List<SetDateAction> actions = new ArrayList<>();
 
         for (var analyzedFile : analyzedFiles) {

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandInput.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandInput.java
@@ -17,5 +17,7 @@ public record SetDateCommandInput(
 
         boolean unknownOnly,
 
-        boolean fixZone) {
+        boolean fixZone,
+
+        String forceField) {
 }

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandRunner.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandRunner.java
@@ -59,6 +59,13 @@ public class SetDateCommandRunner implements CommandRunner {
                     "Uses existing EXIF date/time but applies the timezone from --zone-id (or default config).")
             .build();
 
+    private static final Option FORCE_FIELD = Option.builder()
+            .option("F")
+            .longOpt("force-field")
+            .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields. Works with --fix-zone and --unknown options.")
+            .hasArg()
+            .build();
+
     private final Console console;
 
     private final SetDateCommand setDateCommand;
@@ -119,6 +126,7 @@ public class SetDateCommandRunner implements CommandRunner {
         boolean rename = cmd.hasOption(RENAME.getOpt());
         boolean unknownOnly = cmd.hasOption(UNKNOWN_ONLY.getOpt());
         boolean fixZone = cmd.hasOption(FIX_ZONE.getOpt());
+        String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
 
         if (fixZone) {
             if (dateTime != null) {
@@ -132,7 +140,7 @@ public class SetDateCommandRunner implements CommandRunner {
             }
         }
 
-        return new SetDateCommandInput(args, patternStr, dateTime, zoneId, rename, unknownOnly, fixZone);
+        return new SetDateCommandInput(args, patternStr, dateTime, zoneId, rename, unknownOnly, fixZone, forceField);
     }
 
     @Override
@@ -154,6 +162,7 @@ public class SetDateCommandRunner implements CommandRunner {
         options.addOption(RENAME);
         options.addOption(UNKNOWN_ONLY);
         options.addOption(FIX_ZONE);
+        options.addOption(FORCE_FIELD);
         return options;
     }
 

--- a/set-date/src/test/java/sk/kubisoft/exifutils/setdate/SetDateCommandTest.java
+++ b/set-date/src/test/java/sk/kubisoft/exifutils/setdate/SetDateCommandTest.java
@@ -94,7 +94,7 @@ class SetDateCommandTest {
                 Collections.emptyMap(), existingDate);
 
         when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
-        when(mediaAnalyzer.analyze(anyList())).thenReturn(List.of(analyzedFile));
+        when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called with Europe/Athens timezone (+03:00 in summer)
         ZoneId correctZone = ZoneId.of("Europe/Athens");
@@ -105,7 +105,8 @@ class SetDateCommandTest {
                 correctZone,
                 false, // no rename
                 false, // not unknownOnly
-                true   // fixZone = true
+                true,  // fixZone = true
+                null   // forceField = null
         );
 
         command.execute(input);
@@ -136,7 +137,7 @@ class SetDateCommandTest {
                 Collections.emptyMap(), existingDate);
 
         when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
-        when(mediaAnalyzer.analyze(anyList())).thenReturn(List.of(analyzedFile));
+        when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called without specifying zoneId (should use default from config)
         SetDateCommandInput input = new SetDateCommandInput(
@@ -146,7 +147,8 @@ class SetDateCommandTest {
                 null,  // no zoneId - should use default
                 false, // no rename
                 false, // not unknownOnly
-                true   // fixZone = true
+                true,  // fixZone = true
+                null   // forceField = null
         );
 
         command.execute(input);
@@ -169,13 +171,13 @@ class SetDateCommandTest {
                 Collections.emptyMap(), null); // no creation date
 
         when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
-        when(mediaAnalyzer.analyze(anyList())).thenReturn(List.of(analyzedFile));
+        when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called
         SetDateCommandInput input = new SetDateCommandInput(
                 new String[]{"/test"},
                 null, null, ZoneId.of("Europe/Paris"),
-                false, false, true
+                false, false, true, null
         );
 
         command.execute(input);

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommand.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommand.java
@@ -55,7 +55,7 @@ public class ShiftDateCommand {
         List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
         console.println("Found %d files.", allMediaFiles.size());
 
-        List<AnalyzedMediaFile> analyzedMediaFiles = mediaAnalyzer.analyze(allMediaFiles);
+        List<AnalyzedMediaFile> analyzedMediaFiles = mediaAnalyzer.analyze(allMediaFiles, input.forceField());
 
         List<AnalyzedMediaFile> mediaFilesWithDate = analyzedMediaFiles.stream()
                 .filter(mediaFile -> mediaFile.getCreationDate() != null)

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandInput.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandInput.java
@@ -8,7 +8,9 @@ public record ShiftDateCommandInput(
 
         Duration duration,
 
-        boolean rename
+        boolean rename,
+
+        String forceField
 ) {
 
 }

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandRunner.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandRunner.java
@@ -30,6 +30,13 @@ public class ShiftDateCommandRunner implements CommandRunner {
             .desc("Rename files according to their original date and time.")
             .build();
 
+    private static final Option FORCE_FIELD = Option.builder()
+            .option("F")
+            .longOpt("force-field")
+            .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
     private final Console console;
 
     private final ShiftDateCommand shiftDateCommand;
@@ -68,7 +75,9 @@ public class ShiftDateCommandRunner implements CommandRunner {
 
         boolean rename = cmd.hasOption(RENAME.getOpt());
 
-        return new ShiftDateCommandInput(args, duration, rename);
+        String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
+
+        return new ShiftDateCommandInput(args, duration, rename, forceField);
     }
 
     @Override
@@ -87,6 +96,7 @@ public class ShiftDateCommandRunner implements CommandRunner {
         var options = new Options();
         options.addOption(DURATION);
         options.addOption(RENAME);
+        options.addOption(FORCE_FIELD);
         return options;
     }
 

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
@@ -46,7 +46,7 @@ public class SortCommand {
         List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
         console.println("Found %d files.", allMediaFiles.size());
 
-        List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(allMediaFiles);
+        List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(allMediaFiles, input.forceField());
 
         List<AnalyzedMediaFile> mediaFilesWithDate = analyzedFiles.stream()
                 .filter(mediaFile -> mediaFile.getCreationDate() != null)

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
@@ -22,7 +22,13 @@ public record SortCommandInput(
          * If true, copy files instead of moving them.
          * Useful for experimenting with sort patterns.
          */
-        boolean copy
+        boolean copy,
+
+        /**
+         * If set, force date extraction from the specified EXIF field,
+         * bypassing device profiles.
+         */
+        String forceField
 
 ) {
 }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
@@ -51,6 +51,13 @@ public class SortCommandRunner implements CommandRunner {
             .desc("Copy files instead of moving them (useful for experimenting with patterns).")
             .build();
 
+    private static final Option FORCE_FIELD = Option.builder()
+            .option("F")
+            .longOpt("force-field")
+            .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
     private final SortCommand sortCommand;
 
     private final Console console;
@@ -116,7 +123,9 @@ public class SortCommandRunner implements CommandRunner {
 
         boolean copyFiles = cmd.hasOption(COPY.getOpt());
 
-        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern, copyFiles);
+        String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
+
+        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern, copyFiles, forceField);
     }
 
     @Override
@@ -137,6 +146,7 @@ public class SortCommandRunner implements CommandRunner {
         options.addOption(WRITE);
         options.addOption(PATTERN);
         options.addOption(COPY);
+        options.addOption(FORCE_FIELD);
         return options;
     }
 


### PR DESCRIPTION
## Summary

- Add `-F/--force-field` option to `rename`, `sort`, `set-date`, and `shift-date` commands
- Allows users to bypass device profiles and extract dates from a specific EXIF field
- Useful for special cases like old MPG files where dates can be extracted from `FileModifyDate`
- Parsed as local time with standard timezone resolution (GPS fallback, config fallback)

## Test plan

- [x] Unit tests added for `ExifDateExtractor` force field extraction
- [x] All existing tests updated and passing
- [x] `mvn clean test` passes with all 25 tests successful
- [ ] Manual testing: `exifutils rename --force-field FileModifyDate <files>`
- [ ] Manual testing: `exifutils sort -F FileModifyDate -o <output> <files>`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)