### PR TITLE
feat: add --order CLI option for input file sort order

### DIFF
--- a/config/application-template.conf
+++ b/config/application-template.conf
@@ -14,6 +14,13 @@ dateTime {
   #timeZone = ""
 }
 
+file {
+  # Order in which input files are processed.
+  # Valid values: name, last-modified, created
+  # Default: name
+  #sortOrder = "name"
+}
+
 sort {
   # Default destination directory for sorted files.
   # If set, the -o/--outputDir option becomes optional.

--- a/core/src/main/java/sk/kubisoft/exifutils/core/config/ConfigService.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/config/ConfigService.java
@@ -8,6 +8,8 @@ import sk.kubisoft.exifutils.core.utils.EnvironmentUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -77,6 +79,11 @@ public class ConfigService {
 			return Optional.empty();
 		}
 		return Optional.of(Paths.get(destination));
+	}
+
+	public FileSortOrder getFileSortOrder() {
+		String sortOrder = config.getString("file.sortOrder");
+		return FileSortOrder.fromString(sortOrder);
 	}
 
 }

--- a/core/src/main/java/sk/kubisoft/exifutils/core/file/FileExplorer.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/file/FileExplorer.java
@@ -1,62 +1,107 @@
 package sk.kubisoft.exifutils.core.file;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import sk.kubisoft.exifutils.core.analysis.MediaTypeDetector;
+import sk.kubisoft.exifutils.core.config.ConfigService;
 import sk.kubisoft.exifutils.core.media.MediaFile;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
 @Singleton
 public class FileExplorer {
 
-    private final FileService fileService;
+    private static final Logger logger = LoggerFactory.getLogger(FileExplorer.class);
 
+    private final FileService fileService;
     private final MediaTypeDetector mediaTypeDetector;
+    private final ConfigService configService;
 
     @Inject
-    public FileExplorer(FileService fileService, MediaTypeDetector mediaTypeDetector) {
+    public FileExplorer(FileService fileService, MediaTypeDetector mediaTypeDetector, ConfigService configService) {
         this.fileService = fileService;
         this.mediaTypeDetector = mediaTypeDetector;
+        this.configService = configService;
     }
 
     public List<Path> listFiles(String[] args) {
+        return listFiles(args, null);
+    }
+
+    public List<Path> listFiles(String[] args, FileSortOrder sortOrder) {
         List<Path> inputPaths = Arrays.stream(args)
                 .map(Paths::get)
                 .toList();
 
-        return listFiles(inputPaths);
+        return listFiles(inputPaths, sortOrder);
     }
 
     public List<Path> listFiles(Path inputPath) {
-        return listFiles(List.of(inputPath));
+        return listFiles(List.of(inputPath), null);
     }
 
     public List<Path> listFiles(List<Path> inputPaths) {
+        return listFiles(inputPaths, null);
+    }
+
+    public List<Path> listFiles(List<Path> inputPaths, FileSortOrder sortOrder) {
         Set<Path> allPaths = new HashSet<>();
         for (var path : inputPaths) {
             checkPath(path);
             allPaths.addAll(listPath(path));
         }
 
+        FileSortOrder effectiveOrder = (sortOrder != null) ? sortOrder : configService.getFileSortOrder();
+
         return allPaths.stream()
-                .sorted()
+                .sorted(getComparator(effectiveOrder))
                 .toList();
     }
 
     public List<MediaFile> listMediaFiles(String[] args) {
+        return listMediaFiles(args, null);
+    }
+
+    public List<MediaFile> listMediaFiles(String[] args, FileSortOrder sortOrder) {
         List<MediaFile> mediaFiles = new ArrayList<>();
-        for (var path : listFiles(args)) {
+        for (var path : listFiles(args, sortOrder)) {
             var mediaType = mediaTypeDetector.detectMediaType(path);
             if (mediaType != null) {
                 mediaFiles.add(new MediaFile(path, mediaType));
             }
         }
         return mediaFiles;
+    }
+
+    private Comparator<Path> getComparator(FileSortOrder sortOrder) {
+        return switch (sortOrder) {
+            case NAME -> Comparator.naturalOrder();
+            case LAST_MODIFIED -> (p1, p2) -> compareByAttribute(p1, p2, false);
+            case CREATED -> (p1, p2) -> compareByAttribute(p1, p2, true);
+        };
+    }
+
+    private int compareByAttribute(Path p1, Path p2, boolean useCreationTime) {
+        try {
+            var attr1 = Files.readAttributes(p1, BasicFileAttributes.class);
+            var attr2 = Files.readAttributes(p2, BasicFileAttributes.class);
+
+            var time1 = useCreationTime ? attr1.creationTime() : attr1.lastModifiedTime();
+            var time2 = useCreationTime ? attr2.creationTime() : attr2.lastModifiedTime();
+
+            return time1.compareTo(time2);
+        } catch (IOException e) {
+            logger.warn("Error reading file attributes for {} or {}: {}", p1, p2, e.getMessage());
+            return 0;
+        }
     }
 
     private List<Path> listPath(Path path) {

--- a/core/src/main/java/sk/kubisoft/exifutils/core/file/FileExplorer.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/file/FileExplorer.java
@@ -14,7 +14,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.*;
+import java.util.function.Function;
 
 @Singleton
 public class FileExplorer {
@@ -84,24 +86,23 @@ public class FileExplorer {
     private Comparator<Path> getComparator(FileSortOrder sortOrder) {
         return switch (sortOrder) {
             case NAME -> Comparator.naturalOrder();
-            case LAST_MODIFIED -> (p1, p2) -> compareByAttribute(p1, p2, false);
-            case CREATED -> (p1, p2) -> compareByAttribute(p1, p2, true);
+            case LAST_MODIFIED -> compareByAttribute(BasicFileAttributes::lastModifiedTime);
+            case CREATED -> compareByAttribute(BasicFileAttributes::creationTime);
         };
     }
 
-    private int compareByAttribute(Path p1, Path p2, boolean useCreationTime) {
-        try {
-            var attr1 = Files.readAttributes(p1, BasicFileAttributes.class);
-            var attr2 = Files.readAttributes(p2, BasicFileAttributes.class);
+    private Comparator<Path> compareByAttribute(Function<BasicFileAttributes, FileTime> timeExtractor) {
+        return (p1, p2) -> {
+            try {
+                var attr1 = Files.readAttributes(p1, BasicFileAttributes.class);
+                var attr2 = Files.readAttributes(p2, BasicFileAttributes.class);
 
-            var time1 = useCreationTime ? attr1.creationTime() : attr1.lastModifiedTime();
-            var time2 = useCreationTime ? attr2.creationTime() : attr2.lastModifiedTime();
-
-            return time1.compareTo(time2);
-        } catch (IOException e) {
-            logger.warn("Error reading file attributes for {} or {}: {}", p1, p2, e.getMessage());
-            return 0;
-        }
+                return timeExtractor.apply(attr1).compareTo(timeExtractor.apply(attr2));
+            } catch (IOException e) {
+                logger.warn("Error reading file attributes for {} or {}: {}", p1, p2, e.getMessage());
+                return 0;
+            }
+        };
     }
 
     private List<Path> listPath(Path path) {

--- a/core/src/main/java/sk/kubisoft/exifutils/core/file/FileSortOrder.java
+++ b/core/src/main/java/sk/kubisoft/exifutils/core/file/FileSortOrder.java
@@ -1,0 +1,19 @@
+package sk.kubisoft.exifutils.core.file;
+
+public enum FileSortOrder {
+    NAME,
+    LAST_MODIFIED,
+    CREATED;
+
+    public static FileSortOrder fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return NAME;
+        }
+        try {
+            return FileSortOrder.valueOf(value.toUpperCase().replace("-", "_"));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid file sort order: '" + value + "'. Valid values: name, last-modified, created");
+        }
+    }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -14,6 +14,15 @@ dateTime {
   timeZone = ""
 }
 
+file {
+  # Order in which input files are processed.
+  # Valid values: name, last-modified, created
+  #   name          - sort by file name (default)
+  #   last-modified - sort by file last modified date
+  #   created       - sort by file creation date
+  sortOrder = "name"
+}
+
 rename {
   # Pattern for new file name, where following variables are available (extension is preserved):
   # ${prefix}: IMG for images, VID for video files

--- a/core/src/test/java/sk/kubisoft/exifutils/core/file/FileExplorerTest.java
+++ b/core/src/test/java/sk/kubisoft/exifutils/core/file/FileExplorerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sk.kubisoft.exifutils.core.analysis.MediaTypeDetector;
+import sk.kubisoft.exifutils.core.config.ConfigService;
 import sk.kubisoft.exifutils.core.media.MediaFile;
 import sk.kubisoft.exifutils.core.media.MediaType;
 
@@ -26,12 +27,15 @@ class FileExplorerTest {
     private FileService fileService;
     @Mock
     private MediaTypeDetector mediaTypeDetector;
+    @Mock
+    private ConfigService configService;
 
     private FileExplorer fileExplorer;
 
     @BeforeEach
     void setUp() throws IOException {
-        fileExplorer = new FileExplorer(fileService, mediaTypeDetector);
+        lenient().when(configService.getFileSortOrder()).thenReturn(FileSortOrder.NAME);
+        fileExplorer = new FileExplorer(fileService, mediaTypeDetector, configService);
         mockTestFiles();
     }
 

--- a/docs/commands/rename.md
+++ b/docs/commands/rename.md
@@ -16,6 +16,7 @@ exifutils rename [OPTIONS] <FILE|DIR>...
 | `--write-date` | `-w` | Write analyzed date to file metadata |
 | `--zone-id` | `-z` | Timezone ID for date writing (requires `-w`) |
 | `--force-field` | `-F` | Force date extraction from specific EXIF field |
+| `--order` | `-O` | Input file ordering: `name`, `last-modified`, `created`. Overrides config |
 
 ## Examples
 

--- a/docs/commands/set-date.md
+++ b/docs/commands/set-date.md
@@ -19,6 +19,7 @@ exifutils set-date [OPTIONS] <FILE|DIR>...
 | `--force-field` | `-F` | Force date extraction from specific EXIF field |
 | `--rename` | `-r` | Rename files after setting date |
 | `--unknown` | `-u` | Only process files with unknown/missing dates |
+| `--order` | `-O` | Input file ordering: `name`, `last-modified`, `created`. Overrides config |
 
 ## Modes
 

--- a/docs/commands/shift-date.md
+++ b/docs/commands/shift-date.md
@@ -15,6 +15,7 @@ exifutils shift-date [OPTIONS] <FILE|DIR>...
 | `--duration` | `-d` | Duration to shift (required). Format: ISO 8601 |
 | `--rename` | `-r` | Rename files after shifting date |
 | `--force-field` | `-F` | Force date extraction from specific EXIF field |
+| `--order` | `-O` | Input file ordering: `name`, `last-modified`, `created`. Overrides config |
 
 ## Duration Format
 

--- a/docs/commands/sort.md
+++ b/docs/commands/sort.md
@@ -18,6 +18,7 @@ exifutils sort [OPTIONS] <FILE|DIR>...
 | `--write-date` | `-w` | Write analyzed date to file metadata |
 | `--copy` | `-c` | Copy files instead of moving them |
 | `--force-field` | `-F` | Force date extraction from specific EXIF field |
+| `--order` | `-O` | Input file ordering: `name`, `last-modified`, `created`. Overrides config |
 
 ## Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,22 @@ dateTime {
 }
 ```
 
+### file
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `file.sortOrder` | `name` | Order in which input files are processed. Values: `name`, `last-modified`, `created` |
+
+```hocon
+file {
+  sortOrder = "created"
+}
+```
+
+This is useful when files have non-meaningful names (e.g., UUIDs) but their filesystem creation or modification dates reflect the correct order.
+
+Can be overridden per-command with the `--order` / `-O` CLI option.
+
 ### rename
 
 | Setting | Default | Description |
@@ -89,6 +105,10 @@ exifTool {
 
 dateTime {
   timeZone = "Europe/Bratislava"
+}
+
+file {
+  sortOrder = "name"
 }
 
 rename {

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommand.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommand.java
@@ -52,7 +52,7 @@ public class RenameCommand {
         console.verboseln("Running ExifUtils Rename command with input: %s", input);
 
         console.println("Searching for media files...");
-        List<MediaFile> mediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
+        List<MediaFile> mediaFiles = fileExplorer.listMediaFiles(input.inputPaths(), input.sortOrder());
         console.println("Found %d files.", mediaFiles.size());
 
         List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(mediaFiles, input.forceField());

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandInput.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandInput.java
@@ -1,5 +1,7 @@
 package sk.kubisoft.exifutils.rename;
 
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
+
 import java.nio.file.Path;
 import java.time.ZoneId;
 
@@ -13,7 +15,9 @@ public record RenameCommandInput(
 
         ZoneId zoneId,
 
-        String forceField
+        String forceField,
+
+        FileSortOrder sortOrder
 
 ) {
 }

--- a/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandRunner.java
+++ b/rename/src/main/java/sk/kubisoft/exifutils/rename/RenameCommandRunner.java
@@ -6,6 +6,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import sk.kubisoft.exifutils.core.CommandArgument;
 import sk.kubisoft.exifutils.core.CommandRunner;
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
 import sk.kubisoft.exifutils.core.logging.Console;
 
 import javax.inject.Inject;
@@ -41,6 +42,13 @@ public class RenameCommandRunner implements CommandRunner {
             .option("F")
             .longOpt("force-field")
             .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
+    private static final Option ORDER = Option.builder()
+            .option("O")
+            .longOpt("order")
+            .desc("Order in which input files are processed. Valid values: name, last-modified, created. Overrides config setting.")
             .hasArg()
             .build();
 
@@ -98,7 +106,16 @@ public class RenameCommandRunner implements CommandRunner {
 
         String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
 
-        return new RenameCommandInput(args, outputDir, writeDate, zoneId, forceField);
+        FileSortOrder sortOrder = null;
+        if (cmd.hasOption(ORDER)) {
+            try {
+                sortOrder = FileSortOrder.fromString(cmd.getOptionValue(ORDER.getOpt()));
+            } catch (IllegalArgumentException e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+
+        return new RenameCommandInput(args, outputDir, writeDate, zoneId, forceField, sortOrder);
     }
 
     @Override
@@ -118,6 +135,7 @@ public class RenameCommandRunner implements CommandRunner {
         options.addOption(ZONE_ID);
         options.addOption(OUTPUT_DIR);
         options.addOption(FORCE_FIELD);
+        options.addOption(ORDER);
         return options;
     }
 

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommand.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommand.java
@@ -58,7 +58,7 @@ public class SetDateCommand {
         console.verboseln("Running ExifUtils Rename command with input: %s", input);
 
         console.println("Searching for media files...");
-        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
+        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths(), input.sortOrder());
         console.println("Found %d files.", allMediaFiles.size());
 
         List<MediaFile> mediaFiles;

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandInput.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandInput.java
@@ -1,5 +1,7 @@
 package sk.kubisoft.exifutils.setdate;
 
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
@@ -19,5 +21,7 @@ public record SetDateCommandInput(
 
         boolean fixZone,
 
-        String forceField) {
+        String forceField,
+
+        FileSortOrder sortOrder) {
 }

--- a/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandRunner.java
+++ b/set-date/src/main/java/sk/kubisoft/exifutils/setdate/SetDateCommandRunner.java
@@ -7,6 +7,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import sk.kubisoft.exifutils.core.CommandArgument;
 import sk.kubisoft.exifutils.core.CommandRunner;
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
 import sk.kubisoft.exifutils.core.logging.Console;
 
 import javax.inject.Inject;
@@ -63,6 +64,13 @@ public class SetDateCommandRunner implements CommandRunner {
             .option("F")
             .longOpt("force-field")
             .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields. Works with --fix-zone and --unknown options.")
+            .hasArg()
+            .build();
+
+    private static final Option ORDER = Option.builder()
+            .option("O")
+            .longOpt("order")
+            .desc("Order in which input files are processed. Valid values: name, last-modified, created. Overrides config setting.")
             .hasArg()
             .build();
 
@@ -128,6 +136,15 @@ public class SetDateCommandRunner implements CommandRunner {
         boolean fixZone = cmd.hasOption(FIX_ZONE.getOpt());
         String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
 
+        FileSortOrder sortOrder = null;
+        if (cmd.hasOption(ORDER)) {
+            try {
+                sortOrder = FileSortOrder.fromString(cmd.getOptionValue(ORDER.getOpt()));
+            } catch (IllegalArgumentException e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+
         if (fixZone) {
             if (dateTime != null) {
                 throw new ParseException("Options --fix-zone and --date-time are mutually exclusive.");
@@ -140,7 +157,7 @@ public class SetDateCommandRunner implements CommandRunner {
             }
         }
 
-        return new SetDateCommandInput(args, patternStr, dateTime, zoneId, rename, unknownOnly, fixZone, forceField);
+        return new SetDateCommandInput(args, patternStr, dateTime, zoneId, rename, unknownOnly, fixZone, forceField, sortOrder);
     }
 
     @Override
@@ -163,6 +180,7 @@ public class SetDateCommandRunner implements CommandRunner {
         options.addOption(UNKNOWN_ONLY);
         options.addOption(FIX_ZONE);
         options.addOption(FORCE_FIELD);
+        options.addOption(ORDER);
         return options;
     }
 

--- a/set-date/src/test/java/sk/kubisoft/exifutils/setdate/SetDateCommandTest.java
+++ b/set-date/src/test/java/sk/kubisoft/exifutils/setdate/SetDateCommandTest.java
@@ -93,7 +93,7 @@ class SetDateCommandTest {
         AnalyzedMediaFile analyzedFile = new AnalyzedMediaFile(testPath, MediaType.IMAGE,
                 Collections.emptyMap(), existingDate);
 
-        when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
+        when(fileExplorer.listMediaFiles(any(), any())).thenReturn(List.of(mediaFile));
         when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called with Europe/Athens timezone (+03:00 in summer)
@@ -106,7 +106,8 @@ class SetDateCommandTest {
                 false, // no rename
                 false, // not unknownOnly
                 true,  // fixZone = true
-                null   // forceField = null
+                null,  // forceField = null
+                null   // sortOrder = null (use config default)
         );
 
         command.execute(input);
@@ -136,7 +137,7 @@ class SetDateCommandTest {
         AnalyzedMediaFile analyzedFile = new AnalyzedMediaFile(testPath, MediaType.IMAGE,
                 Collections.emptyMap(), existingDate);
 
-        when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
+        when(fileExplorer.listMediaFiles(any(), any())).thenReturn(List.of(mediaFile));
         when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called without specifying zoneId (should use default from config)
@@ -148,7 +149,8 @@ class SetDateCommandTest {
                 false, // no rename
                 false, // not unknownOnly
                 true,  // fixZone = true
-                null   // forceField = null
+                null,  // forceField = null
+                null   // sortOrder = null (use config default)
         );
 
         command.execute(input);
@@ -170,14 +172,14 @@ class SetDateCommandTest {
         AnalyzedMediaFile analyzedFile = new AnalyzedMediaFile(testPath, MediaType.IMAGE,
                 Collections.emptyMap(), null); // no creation date
 
-        when(fileExplorer.listMediaFiles(any())).thenReturn(List.of(mediaFile));
+        when(fileExplorer.listMediaFiles(any(), any())).thenReturn(List.of(mediaFile));
         when(mediaAnalyzer.analyze(anyList(), any())).thenReturn(List.of(analyzedFile));
 
         // When: fix-zone is called
         SetDateCommandInput input = new SetDateCommandInput(
                 new String[]{"/test"},
                 null, null, ZoneId.of("Europe/Paris"),
-                false, false, true, null
+                false, false, true, null, null
         );
 
         command.execute(input);

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommand.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommand.java
@@ -52,7 +52,7 @@ public class ShiftDateCommand {
         console.verboseln("Running ExifUtils shift-date command with input: %s", input);
 
         console.println("Searching for media files...");
-        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
+        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths(), input.sortOrder());
         console.println("Found %d files.", allMediaFiles.size());
 
         List<AnalyzedMediaFile> analyzedMediaFiles = mediaAnalyzer.analyze(allMediaFiles, input.forceField());

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandInput.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandInput.java
@@ -1,5 +1,7 @@
 package sk.kubisoft.exifutils.shiftdate;
 
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
+
 import java.time.Duration;
 
 public record ShiftDateCommandInput(
@@ -10,7 +12,9 @@ public record ShiftDateCommandInput(
 
         boolean rename,
 
-        String forceField
+        String forceField,
+
+        FileSortOrder sortOrder
 ) {
 
 }

--- a/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandRunner.java
+++ b/shift-date/src/main/java/sk/kubisoft/exifutils/shiftdate/ShiftDateCommandRunner.java
@@ -6,6 +6,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import sk.kubisoft.exifutils.core.CommandArgument;
 import sk.kubisoft.exifutils.core.CommandRunner;
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
 import sk.kubisoft.exifutils.core.logging.Console;
 
 import javax.inject.Inject;
@@ -34,6 +35,13 @@ public class ShiftDateCommandRunner implements CommandRunner {
             .option("F")
             .longOpt("force-field")
             .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
+    private static final Option ORDER = Option.builder()
+            .option("O")
+            .longOpt("order")
+            .desc("Order in which input files are processed. Valid values: name, last-modified, created. Overrides config setting.")
             .hasArg()
             .build();
 
@@ -77,7 +85,16 @@ public class ShiftDateCommandRunner implements CommandRunner {
 
         String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
 
-        return new ShiftDateCommandInput(args, duration, rename, forceField);
+        FileSortOrder sortOrder = null;
+        if (cmd.hasOption(ORDER)) {
+            try {
+                sortOrder = FileSortOrder.fromString(cmd.getOptionValue(ORDER.getOpt()));
+            } catch (IllegalArgumentException e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+
+        return new ShiftDateCommandInput(args, duration, rename, forceField, sortOrder);
     }
 
     @Override
@@ -97,6 +114,7 @@ public class ShiftDateCommandRunner implements CommandRunner {
         options.addOption(DURATION);
         options.addOption(RENAME);
         options.addOption(FORCE_FIELD);
+        options.addOption(ORDER);
         return options;
     }
 

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommand.java
@@ -43,7 +43,7 @@ public class SortCommand {
         console.verboseln("Running ExifUtils Sort command with input: {}", input);
 
         console.println("Searching for media files...");
-        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths());
+        List<MediaFile> allMediaFiles = fileExplorer.listMediaFiles(input.inputPaths(), input.sortOrder());
         console.println("Found %d files.", allMediaFiles.size());
 
         List<AnalyzedMediaFile> analyzedFiles = mediaAnalyzer.analyze(allMediaFiles, input.forceField());

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandInput.java
@@ -1,5 +1,7 @@
 package sk.kubisoft.exifutils.sort;
 
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
+
 import java.nio.file.Path;
 
 public record SortCommandInput(
@@ -28,7 +30,9 @@ public record SortCommandInput(
          * If set, force date extraction from the specified EXIF field,
          * bypassing device profiles.
          */
-        String forceField
+        String forceField,
+
+        FileSortOrder sortOrder
 
 ) {
 }

--- a/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
+++ b/sort/src/main/java/sk/kubisoft/exifutils/sort/SortCommandRunner.java
@@ -7,6 +7,7 @@ import org.apache.commons.cli.ParseException;
 import sk.kubisoft.exifutils.core.CommandArgument;
 import sk.kubisoft.exifutils.core.CommandRunner;
 import sk.kubisoft.exifutils.core.config.ConfigService;
+import sk.kubisoft.exifutils.core.file.FileSortOrder;
 import sk.kubisoft.exifutils.core.logging.Console;
 
 import javax.inject.Inject;
@@ -55,6 +56,13 @@ public class SortCommandRunner implements CommandRunner {
             .option("F")
             .longOpt("force-field")
             .desc("Force date extraction from the specified EXIF field, bypassing device profiles. Use 'info -a' to list available fields.")
+            .hasArg()
+            .build();
+
+    private static final Option ORDER = Option.builder()
+            .option("O")
+            .longOpt("order")
+            .desc("Order in which input files are processed. Valid values: name, last-modified, created. Overrides config setting.")
             .hasArg()
             .build();
 
@@ -125,7 +133,16 @@ public class SortCommandRunner implements CommandRunner {
 
         String forceField = cmd.getOptionValue(FORCE_FIELD.getOpt());
 
-        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern, copyFiles, forceField);
+        FileSortOrder sortOrder = null;
+        if (cmd.hasOption(ORDER)) {
+            try {
+                sortOrder = FileSortOrder.fromString(cmd.getOptionValue(ORDER.getOpt()));
+            } catch (IllegalArgumentException e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+
+        return new SortCommandInput(args, outputDir, renameFiles, writeDate, sortPattern, copyFiles, forceField, sortOrder);
     }
 
     @Override
@@ -147,6 +164,7 @@ public class SortCommandRunner implements CommandRunner {
         options.addOption(PATTERN);
         options.addOption(COPY);
         options.addOption(FORCE_FIELD);
+        options.addOption(ORDER);
         return options;
     }
 


### PR DESCRIPTION
## Summary
- Adds `FileSortOrder` enum (`NAME`, `LAST_MODIFIED`, `CREATED`) to control input file processing order
- Adds `file.sortOrder` config setting in `reference.conf` (default: `name`)
- Adds `--order` / `-O` CLI option to set-date, rename, shift-date, and sort commands to override config per-invocation
- Refactors `FileExplorer` to use `ConfigService` for default sort order with proper comparator logic and logging

## Test plan
- [x] All existing tests pass (`mvn test`)
- [ ] Verify `--order created` sorts files by filesystem creation date
- [ ] Verify `--order last-modified` sorts files by last modified date
- [ ] Verify default behavior (sort by name) is preserved
- [ ] Verify `file.sortOrder` config setting works as fallback
- [ ] Verify invalid `--order` value produces clear error message

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)